### PR TITLE
4/#5 kimjuha working

### DIFF
--- a/index.css
+++ b/index.css
@@ -103,10 +103,17 @@ div {
 .toggleBtn:hover {
   background-color: #dbdbdb;
 }
-.add,
+.addChild,
 .delete {
+  background-color: #faf3dd;
   cursor: pointer;
   margin-left: 10px;
-  font-size: medium;
+  font-size: large;
   border: none;
+  border-radius: 10px;
+  width: 2rem;
+}
+.addChild:hover,
+.delete:hover {
+  background-color: gray;
 }

--- a/src/page/editor/Editor.js
+++ b/src/page/editor/Editor.js
@@ -32,6 +32,17 @@ export default function Editor({
         `;
       isInitialize = true;
     }
+
+    const $sidebarTitle = document.getElementById(`span-${this.state.id}`);
+    if ($sidebarTitle === null) return;
+
+    $sidebarTitle.innerText = this.state.title ? this.state.title : "제목 없음";
+
+    if (this.state.title === "") {
+      const editorTitle = document.querySelector("input");
+      this.state.title = "제목 없음";
+      editorTitle.placeholder = "제목 없음";
+    }
   };
 
   this.render();

--- a/src/page/sidebar/DocumentListRenderer.js
+++ b/src/page/sidebar/DocumentListRenderer.js
@@ -45,7 +45,7 @@ const listRendererTemplate = (item, depth) => {
   return `
     <li data-id="${id}" style="padding-left: ${depth}px;">
         <button id="toggleBtn-${id}" data-id="${id}" data-isToggled="false" class="toggleBtn">▶︎</button>
-        <span data-id="${id}" class="documentTitle">${title}</span>
+        <span id="span-${id}" data-id="${id}" class="documentTitle">${title}</span>
         <button data-id="${id}" class="addChild">+</button>
         <button data-id="${id}" class="delete">-</button>
     </li>

--- a/src/page/sidebar/handlerEvent.js
+++ b/src/page/sidebar/handlerEvent.js
@@ -14,10 +14,10 @@ export const onClickDocument = (target) => {
   }
 };
 
-export const onClickHeader = async (target) => {
+export const onClickHeader = (target) => {
   const $header = target.closest(".header");
   if ($header) {
-    await pushRouter("/");
+    pushRouter("/");
   }
 };
 
@@ -25,7 +25,7 @@ export const onClickBtn = async (target, state, username) => {
   if (target.tagName === "BUTTON") {
     switch (target.className) {
       case "addChild":
-        await addChildDocument(target);
+        addChildDocument(target);
         break;
       case "delete":
         await deleteDocument(target, state, username);

--- a/src/utils/btnEvent.js
+++ b/src/utils/btnEvent.js
@@ -2,9 +2,9 @@ import { pushRouter } from "./router.js";
 import { pushNewPost } from "./btnCustomEvent.js";
 import { deleteApi } from "./api.js";
 
-export const addChildDocument = async (target) => {
+export const addChildDocument = (target) => {
   const { id } = target.dataset;
-  await pushNewPost(id);
+  pushNewPost(id);
 };
 
 export const toggleChildDocument = (target) => {


### PR DESCRIPTION
## 피드백 반영

- 새로운 자식 문서 추가 시, 아코디언 버튼이 닫혀버리는 버그 수정.
- 자식 문서를 추가하거나 삭제할 때, sidebar 전체 부분이 재렌더링 되는 것을 없애고, 변경되는 부분만 렌더링되게 구현.


## 새로운 기능

- editor에서 title을 수정할 때, sidebar의 제목이 동시에 수정되는 낙관적 업데이트 적용.


## 피드백 받고 싶은 점

- 메인 화면 ('/') 에서는 괜찮은데, 다른 파일에 있을 때 (/documents/id) 새로고침하면 css가 전부 깨지는 현상이 발생합니다 ㅠㅠ 많이 알아봤는데, 아직 명확한 해답을 못찾았습니다. 혹시 해결하는 방법을 아시는 분 피드백 주시면 감사하겠습니다~!